### PR TITLE
feat(nvim): add telescope-undo plugin

### DIFF
--- a/nvim/lua/plugins/telesope-undo.lua
+++ b/nvim/lua/plugins/telesope-undo.lua
@@ -1,0 +1,32 @@
+return {
+  "debugloop/telescope-undo.nvim",
+  dependencies = { -- note how they're inverted to above example
+    {
+      "nvim-telescope/telescope.nvim",
+      dependencies = { "nvim-lua/plenary.nvim" },
+    },
+  },
+  keys = {
+    { -- lazy style key map
+      "<leader>cu",
+      "<cmd>Telescope undo<cr>",
+      desc = "Undo history",
+    },
+  },
+  opts = {
+    -- don't use `defaults = { }` here, do this in the main telescope spec
+    extensions = {
+      undo = {
+        -- telescope-undo.nvim config, see below
+      },
+      -- no other extensions here, they can have their own spec too
+    },
+  },
+  config = function(_, opts)
+    -- Calling telescope's setup from multiple specs does not hurt, it will happily merge the
+    -- configs for us. We won't use data, as everything is in it's own namespace (telescope
+    -- defaults, as well as each extension).
+    require("telescope").setup(opts)
+    require("telescope").load_extension("undo")
+  end,
+}


### PR DESCRIPTION
This commit adds the telescope-undo plugin to the telescope plugin. It
uses <leader>cu to open the telescope undo history.
