### PR TITLE
Update Neovim configuration and GIT_EDITOR path

### DIFF
--- a/.path
+++ b/.path
@@ -6,6 +6,6 @@ export NVM_DIR="$HOME/.nvm"
 export PATH="/usr/local/opt/llvm/bin:$PATH"
 export PATH="$HOME/pyenv/bin:$PATH"
 export PATH="$HOME/Library/Python/3.9/bin:$PATH"
-export GIT_EDITOR="/usr/local/bin/nvim"
+export GIT_EDITOR="/opt/homebrew/bin/nvim"
 export TERM=xterm-256color
 export LANG=en_US.UTF-8

--- a/makefiles/editors.mk
+++ b/makefiles/editors.mk
@@ -1,9 +1,15 @@
 # Editor configuration setups
 
+.PHONY: nvim
+
 nvim: ## Setup Neovim configuration by linking dotfiles
 	@$(call mkdir_safe,${XDG_CONFIG_HOME}/nvim)
-	@for file in $(DOTFILES)/nvim/*; do \
-		ln -f $$file ${XDG_CONFIG_HOME}/nvim/; \
+	@for item in $(DOTFILES)/nvim/*; do \
+		if [ -d "$$item" ]; then \
+			ln -sfn $$item ${XDG_CONFIG_HOME}/nvim/; \
+		else \
+			ln -sf $$item ${XDG_CONFIG_HOME}/nvim/; \
+		fi; \
 	done
 
 vim: ## Setup Vim configuration and update submodules

--- a/makefiles/targets.mk
+++ b/makefiles/targets.mk
@@ -5,3 +5,5 @@ personal: vim vscodevim ideavim gvim nvim vsvim bash zsh personal-git yamllint c
 
 # Setup work environment
 work: vim vscodevim ideavim gvim nvim vsvim bash zsh work-git yamllint continue
+
+PHONY: nvim


### PR DESCRIPTION
### Summary
- Updated the GIT_EDITOR path to use the Homebrew installation of Neovim.
- Enhanced the Neovim setup in the makefile to handle directories and files separately.
- Added a PHONY target for Neovim in the makefile.

### Additional Notes
- The changes ensure that the Neovim configuration is correctly linked, whether it is a file or a directory.
- The GIT_EDITOR path update reflects the new location of Neovim installed via Homebrew.