### PR TITLE
feat: update nvim-surround and telescope configurations

### DIFF
--- a/ai-stuff/cursor/.cursorrules
+++ b/ai-stuff/cursor/.cursorrules
@@ -10,6 +10,7 @@
             "Create the gh CLI command to create a GitHub issue."
           ],
           "output_instructions": [
+            "Output needs to be a bash script that can be run in a terminal.",
             "Make the title descriptive and imperative.",
             "No acceptance criteria is needed.",
             "Output the entire `gh issue create` command, including all arguments and the full issue body, in a single code block.",
@@ -65,6 +66,7 @@
             }
           ],
           "output_instructions": [
+            "Output needs to be a bash script that can be run in a terminal.",
             "Use conventional commits",
             "Types other than feat and fix are allowed. build, chore, ci, docs, style, test, perf, refactor, and others.",
             "Only use lowercase letters in the entire body of the commit message",
@@ -117,7 +119,7 @@
             "Create the gh CLI command to create a GitHub issue."
           ],
           "output_sections": {
-            "gh_cli_command": "Output the command to create a pull request using the gh CLI in a single command",
+            "gh_cli_command": "Output the command to create a pull request using the gh CLI in a single command. It should be a bash script that can be run in a terminal.",
             "summary": "Start with a brief summary of the changes made. This should be a concise explanation of the overall changes.",
             "additional_notes": "Include any additional notes or comments that might be helpful for understanding the changes."
           },

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -2,3 +2,5 @@
 require("config.lazy")
 -- setup command abbreviations
 require("config.misc")
+-- setup vscode keymaps
+require("config.vscode_keymaps")

--- a/nvim/lua/plugins/nvim-surround.lua
+++ b/nvim/lua/plugins/nvim-surround.lua
@@ -6,52 +6,18 @@ return {
   config = function()
     require("nvim-surround").setup({
       keymaps = {
-          insert = "<C-g>s",
-          insert_line = "<C-g>S",
-          normal = "<leader>S",
-          normal_cur = "<leader>SS",
-          normal_line = "<leader>S_",
-          normal_cur_line = "<leader>S__",
-          visual = "<leader>S",
-          visual_line = "<leader>S_",
-          delete = "ds",
-          change = "cs",
+        insert = "<C-g>s",
+        insert_line = "<C-g>S",
+        normal = "ys",
+        normal_cur = "yss",
+        normal_line = "yS",
+        normal_cur_line = "ySS",
+        visual = "S",
+        visual_line = "gS",
+        delete = "ds",
+        change = "cs",
+        change_line = "cS",
       },
-  })
-    if not vim.g.vscode then
-      -- Setup which-key descriptions for nvim-surround keymaps
-      local wk = require("which-key")
-      local mappings = {
-        { mode = { "n", "v" } },
-        { "<leader>S", group = "surround" },
-        { "<leader>Sa", group = "around" },
-        { "<leader>Si", group = "inside" },
-        { '<leader>Sa"', desc = "Surround around double quotes" },
-        { "<leader>Sa'", desc = "Surround around single quotes" },
-        { "<leader>Sa(", desc = "Surround around parentheses" },
-        { "<leader>Sa<", desc = "Surround around angle brackets" },
-        { "<leader>SaW", desc = "Surround around WORD" },
-        { "<leader>Sa[", desc = "Surround around brackets" },
-        { "<leader>Sa`", desc = "Surround around backticks" },
-        { "<leader>Sap", desc = "Surround around paragraph" },
-        { "<leader>Sas", desc = "Surround around sentence" },
-        { "<leader>Sat", desc = "Surround around tag block" },
-        { "<leader>Saw", desc = "Surround around word" },
-        { "<leader>Sa{", desc = "Surround around braces" },
-        { '<leader>Si"', desc = "Surround inside double quotes" },
-        { "<leader>Si'", desc = "Surround inside single quotes" },
-        { "<leader>Si(", desc = "Surround inside parentheses" },
-        { "<leader>Si<", desc = "Surround inside angle brackets" },
-        { "<leader>SiW", desc = "Surround inside WORD" },
-        { "<leader>Si[", desc = "Surround inside brackets" },
-        { "<leader>Si`", desc = "Surround inside backticks" },
-        { "<leader>Sip", desc = "Surround inside paragraph" },
-        { "<leader>Sis", desc = "Surround inside sentence" },
-        { "<leader>Sit", desc = "Surround inside tag block" },
-        { "<leader>Siw", desc = "Surround inside word" },
-        { "<leader>Si{", desc = "Surround inside braces" },
-      }
-      wk.add(mappings)
-    end
+    })
   end,
 }

--- a/nvim/lua/plugins/telescope.lua
+++ b/nvim/lua/plugins/telescope.lua
@@ -1,4 +1,5 @@
 -- Inspired from https://www.reddit.com/r/neovim/comments/16ikt0q/telescope_live_grep_search_some_hidden_files/
+-- TODO: the live grep is ignoring some files where it shouldn't.
 
 return {
   "nvim-telescope/telescope.nvim",
@@ -16,14 +17,17 @@ return {
     telescope.setup({
       pickers = {
         live_grep = {
-          file_ignore_patterns = { "node_modules", ".git", ".venv" },
-          additional_args = function(_)
-            return { "--hidden" }
-          end,
+          file_ignore_patterns = { "node_modules/", ".git/", ".venv/" },
+          additional_args = { "--hidden" },
+        },
+        grep_string = {
+          file_ignore_patterns = { "node_modules/", ".git/", ".venv/" },
+          additional_args = { "--hidden" },
         },
         find_files = {
-          file_ignore_patterns = { "node_modules", ".git", ".venv" },
+          file_ignore_patterns = { "node_modules/", ".git/", ".venv/" },
           hidden = true,
+          case_mode = "ignore_case",
         },
       },
     })


### PR DESCRIPTION
This PR includes several updates to our Neovim configuration:

Summary:
- Updated nvim-surround plugin configuration
- Modified telescope.nvim settings for improved file searching
- Added VSCode keymaps setup in init.lua

Changes:
1. nvim-surround:
   - Simplified keymaps configuration
   - Removed VSCode-specific setup and which-key integration

2. telescope.nvim:
   - Added file ignore patterns for live_grep and grep_string
   - Set additional args for hidden file search
   - Improved find_files configuration with case-insensitive search

3. init.lua:
   - Added requirement for VSCode keymaps setup

Additional Notes:
- The live grep functionality in telescope may still be ignoring some files unexpectedly. This has been noted with a TODO comment for future investigation.
- These changes aim to streamline our Neovim configuration and improve search functionality.

Resolves #75, Resolves #76