### PR TITLE
Refactor VSCode Keymaps and Plugin Configuration

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -2,5 +2,3 @@
 require("config.lazy")
 -- setup command abbreviations
 require("config.misc")
--- setup vscode keymaps
-require("config.vscode_keymaps")

--- a/nvim/lua/config/vscode_keymaps.lua
+++ b/nvim/lua/config/vscode_keymaps.lua
@@ -1,6 +1,0 @@
--- Undo/Redo Correction for VSCode
-if vim.g.vscode then
-  vim.keymap.set("n", "u", "<Cmd>call VSCodeNotify('undo')<CR>")
-  vim.keymap.set("n", "<C-r>", "<Cmd>call VSCodeNotify('redo')<CR>")
-  vim.keymap.set( "n", "<leader>t", "<Cmd>call VSCodeNotify('workbench.action.terminal.toggleTerminal')<CR>")
-end

--- a/nvim/lua/plugins/vscode.lua
+++ b/nvim/lua/plugins/vscode.lua
@@ -1,0 +1,20 @@
+return {
+    "LazyVim/LazyVim",
+    vscode = true,
+    opts = function(_, opts)
+        -- print something so that we know that the plugin is loaded
+        print("VSCode plugin loaded")
+
+        -- Set VSCode-specific keymaps after a short delay
+        vim.defer_fn(function()
+            -- Undo/Redo Correction for VSCode
+            vim.keymap.set("n", "u", "<Cmd>call VSCodeNotify('undo')<CR>")
+            vim.keymap.set("n", "<C-r>", "<Cmd>call VSCodeNotify('redo')<CR>")
+            vim.keymap.set("n", "<leader>t", "<Cmd>call VSCodeNotify('workbench.action.terminal.toggleTerminal')<CR>")
+
+            -- Tab navigation for VSCode
+            vim.keymap.set("n", "<S-h>", "<Cmd>call VSCodeNotify('workbench.action.previousEditor')<CR>")
+            vim.keymap.set("n", "<S-l>", "<Cmd>call VSCodeNotify('workbench.action.nextEditor')<CR>")
+        end, 100)  -- 100ms delay
+    end,
+}


### PR DESCRIPTION
## Summary
This pull request refactors the VSCode-specific keymaps configuration by moving it to a dedicated plugin configuration file. This change aims to improve the organization and maintainability of the Neovim configuration.

## Changes
- Removed the `vscode_keymaps.lua` file from `nvim/lua/config/`.
- Added a new `vscode.lua` file in `nvim/lua/plugins/` to handle VSCode-specific keymaps.
- Updated `init.lua` to require `config.misc` instead of `config.vscode_keymaps`.

## Additional Notes
- The new `vscode.lua` plugin configuration file includes a 100ms delay before setting the keymaps to ensure compatibility with VSCode.
- The keymaps for undo, redo, terminal toggle, and tab navigation are now set within the `vscode.lua` file.
- This refactor helps in keeping the configuration modular and easier to manage.