### PR TITLE
Remove VSCode plugin and update keymaps

### DIFF
--- a/nvim/lua/config/lazy.lua
+++ b/nvim/lua/config/lazy.lua
@@ -21,7 +21,6 @@ require("lazy").setup({
     { import = "lazyvim.plugins.extras.lang.go" },
     { import = "lazyvim.plugins.extras.lang.yaml" },
     { import = "lazyvim.plugins.extras.ui.alpha" },
-    { import = "lazyvim.plugins.extras.vscode" },
     -- import/override with your plugins
     { import = "plugins" },
   },
@@ -42,8 +41,6 @@ require("lazy").setup({
       disabled_plugins = {
         "gzip",
         "matchit",
-        -- "matchparen",
-        -- "netrwPlugin",
         "tarPlugin",
         "tohtml",
         "tutor",

--- a/nvim/lua/plugins/vscode.lua
+++ b/nvim/lua/plugins/vscode.lua
@@ -1,20 +1,58 @@
-return {
-    "LazyVim/LazyVim",
-    vscode = true,
-    opts = function(_, opts)
-        -- print something so that we know that the plugin is loaded
-        print("VSCode plugin loaded")
+if not vim.g.vscode then
+    return {}
+  end
 
-        -- Set VSCode-specific keymaps after a short delay
-        vim.defer_fn(function()
-            -- Undo/Redo Correction for VSCode
-            vim.keymap.set("n", "u", "<Cmd>call VSCodeNotify('undo')<CR>")
-            vim.keymap.set("n", "<C-r>", "<Cmd>call VSCodeNotify('redo')<CR>")
-            vim.keymap.set("n", "<leader>t", "<Cmd>call VSCodeNotify('workbench.action.terminal.toggleTerminal')<CR>")
+  local enabled = {
+    "flit.nvim",
+    "lazy.nvim",
+    "leap.nvim",
+    "nvim-treesitter",
+    "nvim-treesitter-textobjects",
+    "nvim-ts-context-commentstring",
+    "ts-comments.nvim",
+    "vim-repeat",
+    "yanky.nvim",
+    "LazyVim",
+  }
 
-            -- Tab navigation for VSCode
-            vim.keymap.set("n", "<S-h>", "<Cmd>call VSCodeNotify('workbench.action.previousEditor')<CR>")
-            vim.keymap.set("n", "<S-l>", "<Cmd>call VSCodeNotify('workbench.action.nextEditor')<CR>")
-        end, 100)  -- 100ms delay
+  local Config = require("lazy.core.config")
+  Config.options.checker.enabled = false
+  Config.options.change_detection.enabled = false
+  Config.options.defaults.cond = function(plugin)
+    return vim.tbl_contains(enabled, plugin.name) or plugin.vscode
+  end
+
+  vim.api.nvim_create_autocmd("User", {
+    pattern = "LazyVimKeymapsDefaults",
+    callback = function()
+      -- Undo/Redo Correction for VSCode
+      vim.keymap.set("n", "u", "<Cmd>call VSCodeNotify('undo')<CR>")
+      vim.keymap.set("n", "<C-r>", "<Cmd>call VSCodeNotify('redo')<CR>")
+      vim.keymap.set("n", "<leader>t", "<Cmd>call VSCodeNotify('workbench.action.terminal.toggleTerminal')<CR>")
+
+      -- VSCode-specific keymaps for search and navigation
+      vim.keymap.set("n", "<leader><space>", "<cmd>Find<cr>")
+      vim.keymap.set("n", "<leader>/", [[<cmd>call VSCodeNotify('workbench.action.findInFiles')<cr>]])
+      vim.keymap.set("n", "<leader>ss", [[<cmd>call VSCodeNotify('workbench.action.gotoSymbol')<cr>]])
+
+      -- Tab navigation for VSCode
+      vim.keymap.set("n", "<S-h>", "<Cmd>call VSCodeNotify('workbench.action.previousEditor')<CR>")
+      vim.keymap.set("n", "<S-l>", "<Cmd>call VSCodeNotify('workbench.action.nextEditor')<CR>")
     end,
-}
+  })
+
+  return {
+    {
+      "LazyVim/LazyVim",
+      config = function(_, opts)
+        opts = opts or {}
+        -- disable the colorscheme
+        opts.colorscheme = function() end
+        require("lazyvim").setup(opts)
+      end,
+    },
+    {
+      "nvim-treesitter/nvim-treesitter",
+      opts = { highlight = { enable = false } },
+    },
+  }


### PR DESCRIPTION
## Summary
This PR removes the VSCode plugin from the configuration and updates the keymaps for better compatibility with VSCode.

## Changes
- Removed the VSCode plugin import from `nvim/lua/config/lazy.lua`.
- Updated the keymaps in `nvim/lua/plugins/vscode.lua` to include VSCode-specific keymaps for search and navigation.
- Disabled certain plugins and features when running in VSCode.

## Additional Notes
- The `nvim/lua/plugins/vscode.lua` file now checks if it is running in VSCode and adjusts the configuration accordingly.
- The `nvim-treesitter` plugin's highlight feature is disabled in VSCode mode.