### PR TITLE
Refactor Keymaps and Add Sidebar Toggle for VSCode

### DIFF
--- a/nvim/lua/config/keymaps.lua
+++ b/nvim/lua/config/keymaps.lua
@@ -92,9 +92,3 @@ vim.keymap.set("n", "<leader><tab><tab>", "<cmd>tabnew<cr>", { desc = "New Tab" 
 vim.keymap.set("n", "<leader><tab>]", "<cmd>tabnext<cr>", { desc = "Next Tab" })
 vim.keymap.set("n", "<leader><tab>d", "<cmd>tabclose<cr>", { desc = "Close Tab" })
 vim.keymap.set("n", "<leader><tab>[", "<cmd>tabprevious<cr>", { desc = "Previous Tab" })
-
--- File Explorer
--- Toggle NvimTree
-vim.keymap.set("n", "<C-b>", ":NvimTreeToggle<CR>", { noremap = true, silent = true, desc = "Toggle file explorer" })
-vim.keymap.set("n", "<leader>e", ":NvimTreeToggle<CR>",
-    { noremap = true, silent = true, desc = "Explorer NvimTree (root dir)" })

--- a/nvim/lua/plugins/copilot-chat.lua
+++ b/nvim/lua/plugins/copilot-chat.lua
@@ -87,7 +87,7 @@ return {
       opts.selection = select.unnamed
 
       local commit_prompt =
-      "Take a deep breath and analyze the changes made in the git diff. Then, write a commit message for the change with commitizen convention, only use lower-case letters. Output the full multi-line command starting with `git commit -m` ready to be pasted into the terminal. If there are backticks in the message, escape them with `\\`."
+      "Take a deep breath and analyze the changes made in the git diff. Then, write a commit message for the change with commitizen convention, only use lower-case letters. Output the full multi-line command starting with `git commit -m` ready to be pasted into the terminal. If there are backticks in the message, escape them with `\\`. When there are multiple changes, use the -m flag to include the changes in an organized manner."
 
       -- Override the git prompts message
       opts.prompts.Commit = {

--- a/nvim/lua/plugins/nvim-tree.lua
+++ b/nvim/lua/plugins/nvim-tree.lua
@@ -34,6 +34,11 @@ return {
           timeout = 500,
         },
       })
+      -- File Explorer Keymaps
+      vim.keymap.set("n", "<C-b>", ":NvimTreeToggle<CR>",
+        { noremap = true, silent = true, desc = "Toggle file explorer" })
+      vim.keymap.set("n", "<leader>e", ":NvimTreeToggle<CR>",
+        { noremap = true, silent = true, desc = "Explorer NvimTree (root dir)" })
     end,
   },
 }

--- a/nvim/lua/plugins/vscode.lua
+++ b/nvim/lua/plugins/vscode.lua
@@ -40,6 +40,10 @@ if not vim.g.vscode then
       -- Tab navigation for VSCode
       vim.keymap.set("n", "<S-h>", "<Cmd>call VSCodeNotify('workbench.action.previousEditor')<CR>")
       vim.keymap.set("n", "<S-l>", "<Cmd>call VSCodeNotify('workbench.action.nextEditor')<CR>")
+
+      -- Toggle Primary Sidebar Like nvim-tree
+      vim.keymap.set("n", "<C-b>", "<Cmd>call VSCodeNotify('workbench.action.toggleSidebarVisibility')<CR>")
+      vim.keymap.set("n", "<leader>e", "<Cmd>call VSCodeNotify('workbench.action.toggleSidebarVisibility')<CR>")
     end,
   })
 


### PR DESCRIPTION
## Summary
This pull request refactors the keymaps configuration by removing redundant keymaps from `keymaps.lua` and re-adding them in their respective plugin configuration files. Additionally, it introduces new keymaps for toggling the primary sidebar in VSCode.

## Changes
- Removed NvimTree toggle keymaps from `keymaps.lua`.
- Added NvimTree toggle keymaps to `nvim-tree.lua`.
- Updated the commit prompt message in `copilot-chat.lua` to include instructions for multiple changes.
- Added keymaps for toggling the primary sidebar in VSCode in `vscode.lua`.

## Additional Notes
- The keymaps for toggling the file explorer have been moved to the `nvim-tree.lua` plugin configuration to keep the keymap definitions organized and relevant to their respective plugins.
- The commit prompt message in `copilot-chat.lua` now includes guidance for handling multiple changes in a commit message.
- The new keymaps for VSCode provide a similar experience to NvimTree toggling, enhancing the consistency across different environments.