### PR TITLE
fix: correct example PR command in copilot-chat plugin

### DIFF
--- a/nvim/lua/plugins/copilot-chat.lua
+++ b/nvim/lua/plugins/copilot-chat.lua
@@ -154,7 +154,7 @@ return {
 
           Example Output:
           ```sh
-          gh pr create --base main --title mytitle --body 'hello
+          gh pr create --base main --title 'commitzen style title' --body 'hello
           multiline
           body'
           ```


### PR DESCRIPTION
## Summary
This pull request corrects the example GitHub pull request command in the `copilot-chat.lua` plugin file.

## Changes
- Updated the example `gh pr create` command to use the correct format for the `--title` flag, ensuring it follows the commitzen convention.

## Additional Notes
This change ensures that users copying the example command will have a properly formatted PR title, avoiding potential issues with command execution.