### PR TITLE
feat(nvim-tree): add key mappings for file explorer

### DIFF
--- a/nvim/lua/plugins/copilot-chat.lua
+++ b/nvim/lua/plugins/copilot-chat.lua
@@ -152,6 +152,44 @@ return {
           - Escape any backticks within the command using backslashes. i.e. \` text with backticks \`
           - Wrap the entire command in a code block for easy copy-pasting.
 
+          Input Format:
+          The expected input format is command line output from git diff that compares all the changes of the current branch with the main repository branch. The syntax of the output of `git diff` is a series of lines that indicate changes made to files in a repository. Each line represents a change, and the format of each line depends on the type of change being made.
+
+          Examples:
+
+          Adding a file:
+          +++ b/newfile.txt
+          @@ -0,0 +1 @@
+          +This is the contents of the new file.
+
+          Deleting a file:
+          --- a/oldfile.txt
+          +++ b/deleted
+          @@ -1 +0,0 @@
+          -This is the contents of the old file.
+
+          Modifying a file:
+          --- a/oldfile.txt
+          +++ b/newfile.txt
+          @@ -1,3 +1,4 @@
+           This is an example of how to modify a file.
+          -The first line of the old file contains this text.
+           The second line contains this other text.
+          +This is the contents of the new file.
+
+          Moving a file:
+          --- a/oldfile.txt
+          +++ b/newfile.txt
+          @@ -1 +1 @@
+           This is an example of how to move a file.
+
+          Renaming a file:
+          --- a/oldfile.txt
+          +++ b/newfile.txt
+          @@ -1 +1,2 @@
+           This is an example of how to rename a file.
+          +This is the contents of the new file.
+
           Example Output:
           ```sh
           gh pr create --base main --title 'commitzen style title' --body 'hello

--- a/nvim/lua/plugins/nvim-tree.lua
+++ b/nvim/lua/plugins/nvim-tree.lua
@@ -4,7 +4,10 @@ return {
     dependencies = {
       "nvim-tree/nvim-web-devicons",
     },
-    event = "VeryLazy",
+    keys = {
+      { "<C-b>", "<cmd>NvimTreeToggle<cr>", desc = "Toggle file explorer" },
+      { "<leader>e", "<cmd>NvimTreeToggle<cr>", desc = "Explorer NvimTree (root dir)" },
+    },
     config = function()
       local status_ok, tree = pcall(require, "nvim-tree")
       local api = require("nvim-tree.api")
@@ -34,10 +37,13 @@ return {
           timeout = 500,
         },
       })
-      -- File Explorer Keymaps
-      vim.keymap.set("n", "<C-b>", ":NvimTreeToggle<CR>",
+
+      -- Override the existing <C-b> mapping
+      vim.keymap.set("n", "<C-b>", "<cmd>NvimTreeToggle<CR>",
         { noremap = true, silent = true, desc = "Toggle file explorer" })
-      vim.keymap.set("n", "<leader>e", ":NvimTreeToggle<CR>",
+
+      -- Keep <leader>e as an alternative
+      vim.keymap.set("n", "<leader>e", "<cmd>NvimTreeToggle<CR>",
         { noremap = true, silent = true, desc = "Explorer NvimTree (root dir)" })
     end,
   },


### PR DESCRIPTION
## Summary
This PR introduces new key mappings for the nvim-tree plugin to enhance the user experience by providing quick access to the file explorer.

## Changes
- Added key mappings for toggling the file explorer:
  - \`<C-b>\` to toggle the file explorer
  - \`<leader>e\` to open the file explorer in the root directory
- Removed the \`event = "VeryLazy"\` configuration as it is no longer necessary with the new key mappings.
- Updated the existing key mappings to use the \`<cmd>\` syntax for consistency and better readability.

## Additional Notes
- The new key mappings provide a more intuitive way to access the file explorer, improving workflow efficiency.
- The \`<C-b>\` mapping overrides the existing mapping to ensure there are no conflicts.
- The \`<leader>e\` mapping is kept as an alternative for users who prefer using the leader key.