### PR TITLE
feat: disable convert to uppercase and lowercase in visual mode

### DIFF
--- a/nvim/lua/plugins/vscode.lua
+++ b/nvim/lua/plugins/vscode.lua
@@ -44,6 +44,9 @@ if not vim.g.vscode then
       -- Toggle Primary Sidebar Like nvim-tree
       vim.keymap.set("n", "<C-b>", "<Cmd>call VSCodeNotify('workbench.action.toggleSidebarVisibility')<CR>")
       vim.keymap.set("n", "<leader>e", "<Cmd>call VSCodeNotify('workbench.action.toggleSidebarVisibility')<CR>")
+
+      -- Disable convert to uppercase and lowercase in visual mode
+      vim.keymap.set('v', {'u', 'U'}, '<Nop>', { noremap = true, silent = true })
     end,
   })
 


### PR DESCRIPTION
## Summary
This pull request introduces a new keymap configuration to disable the conversion to uppercase and lowercase in visual mode within the VSCode plugin configuration for Neovim.

## Changes
- Added a keymap to disable `u` and \`U\` in visual mode by mapping them to \`<Nop>\`.
- This change prevents accidental case conversion when using visual mode.

## Additional Notes
- The change is encapsulated within the condition that checks if the environment is not VSCode, ensuring it does not affect other environments.
- The keymap is set with \`noremap\` and \`silent\` options to ensure no recursive mapping and to suppress any output or error messages.