### PR TITLE
fix: separate keymaps for 'u' and 'U' in visual mode

### DIFF
--- a/nvim/lua/plugins/vscode.lua
+++ b/nvim/lua/plugins/vscode.lua
@@ -46,7 +46,8 @@ if not vim.g.vscode then
       vim.keymap.set("n", "<leader>e", "<Cmd>call VSCodeNotify('workbench.action.toggleSidebarVisibility')<CR>")
 
       -- Disable convert to uppercase and lowercase in visual mode
-      vim.keymap.set('v', {'u', 'U'}, '<Nop>', { noremap = true, silent = true })
+      vim.keymap.set('v', 'u', '<Nop>', { noremap = true, silent = true })
+      vim.keymap.set('v', 'U', '<Nop>', { noremap = true, silent = true })
     end,
   })
 


### PR DESCRIPTION
This PR separates the keymaps for 'u' and 'U' in visual mode to fix an error in the keymap setting.

Summary:
- Replace the single keymap setting that used a table of keys with two separate keymap settings.
- This change fixes an error where vim.keymap.set() was being called with an invalid first argument (a table instead of a string).

Additional Notes:
- The functionality remains the same: both lowercase 'u' and uppercase 'U' are mapped to do nothing ('<Nop>') in visual mode.
- This change improves code clarity and resolves the error in keymap setting.