### PR TITLE
fix: fetch latest changes and update key mappings

### DIFF
--- a/nvim/lua/plugins/copilot-chat.lua
+++ b/nvim/lua/plugins/copilot-chat.lua
@@ -192,9 +192,11 @@ return {
 
           Example Output:
           ```sh
-          gh pr create --base main --title 'commitzen style title' --body 'hello
+          gh pr create --base main --title "commitzen style title" --body "hello
           multiline
-          body'
+          body
+          with \`escaped backticks\`
+          "
           ```
         ]],
         prompt = "Please create a pull request for the following code changes.",

--- a/nvim/lua/plugins/copilot-chat.lua
+++ b/nvim/lua/plugins/copilot-chat.lua
@@ -110,6 +110,9 @@ return {
           return nil
         end
 
+        -- Fetch the latest changes from the remote repository
+        vim.fn.system("git fetch origin main")
+
         local current_branch = vim.fn.system("git rev-parse --abbrev-ref HEAD"):gsub("\n", "")
         local cmd = string.format("git diff --no-color --no-ext-diff origin/main...%s", current_branch)
         local handle = io.popen(cmd)

--- a/nvim/lua/plugins/vscode.lua
+++ b/nvim/lua/plugins/vscode.lua
@@ -46,7 +46,8 @@ if not vim.g.vscode then
       vim.keymap.set("n", "<leader>e", "<Cmd>call VSCodeNotify('workbench.action.toggleSidebarVisibility')<CR>")
 
       -- Disable convert to uppercase and lowercase in visual mode
-      vim.keymap.set('v', {'u', 'U'}, '<Nop>', { noremap = true, silent = true })
+      vim.keymap.set('v', 'u', '<Nop>', { noremap = true, silent = true })
+      vim.keymap.set('v', 'U', '<Nop>', { noremap = true, silent = true })
     end,
   })
 


### PR DESCRIPTION
## Summary
This pull request includes two main changes: fetching the latest changes from the remote repository before generating a diff and updating key mappings in visual mode.

## Changes
- Added a command to fetch the latest changes from the remote repository in `copilot-chat.lua`.
- Updated the example output in the documentation to properly escape backticks.
- Split the key mappings for disabling convert to uppercase and lowercase in visual mode in `vscode.lua`.

## Additional Notes
- The fetch command ensures that the diff is generated against the latest changes from the remote repository.
- The key mappings update in `vscode.lua` improves clarity and maintainability.
