### PR TITLE
feat: add Karabiner configuration and update Makefile scripts

### DIFF
--- a/makefiles/tools.mk
+++ b/makefiles/tools.mk
@@ -13,3 +13,7 @@ yamllint: ## Set up yamllint with custom configuration in the config directory
 continue:
 	$(call mkdir_safe,${HOME}/.continue)
 	$(call symlink,ai-stuff/continue/config.json,${HOME}/.continue/config.json)
+
+karabiner:
+	$(call mkdir_safe,${HOME}/.config/karabiner)
+	$(call symlink,other/karabiner/karabiner.json,${HOME}/.config/karabiner/karabiner.json)

--- a/makefiles/utils.mk
+++ b/makefiles/utils.mk
@@ -5,7 +5,7 @@ update-vim-plugins: ## Update vim plugins to the latest version with submodules
 	git submodule update --init --recursive
 
 # Clean configuration
-clean: ## Clean up all configurations
+clean:
 	$(call remove_file,${HOME}/.vim_runtime)
 	$(call remove_file,${HOME}/.vim/view/*)
 	$(call remove_file,${HOME}/.vimrc)
@@ -16,6 +16,7 @@ clean: ## Clean up all configurations
 	$(call remove_file,${HOME}/.local/share/nvim)
 	$(call remove_file,${HOME}/.local/state/nvim)
 	$(call remove_file,${XDG_CONFIG_HOME}/terminator/config)
+	$(call remove_file,${HOME}/.config/karabiner/karabiner.json)
 	$(call remove_file,${HOME}/.ideavimrc)
 	$(call remove_file,${HOME}/.gvimrc)
 	$(call remove_file,${HOME}/.gitconfig)

--- a/other/karabiner/karabiner.json
+++ b/other/karabiner/karabiner.json
@@ -1,0 +1,456 @@
+{
+  "profiles": [
+    {
+      "complex_modifications": {
+        "rules": [
+          {
+            "description": "For VSCode, VSCode Insiders, and Cursor: Function keys (F1-F12) act as standard function keys. Pressing fn + Function key performs the corresponding media function.",
+            "manipulators": [
+              {
+                "conditions": [
+                  {
+                    "bundle_identifiers": [
+                      "com.microsoft.VSCode",
+                      "com.microsoft.VSCodeInsiders"
+                    ],
+                    "file_paths": ["/Cursor.app$", "/Cursor$"],
+                    "type": "frontmost_application_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "f1",
+                  "modifiers": { "mandatory": ["fn"] }
+                },
+                "to": [{ "consumer_key_code": "display_brightness_decrement" }],
+                "type": "basic"
+              },
+              {
+                "conditions": [
+                  {
+                    "bundle_identifiers": [
+                      "com.microsoft.VSCode",
+                      "com.microsoft.VSCodeInsiders"
+                    ],
+                    "file_paths": ["/Cursor.app$", "/Cursor$"],
+                    "type": "frontmost_application_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "f2",
+                  "modifiers": { "mandatory": ["fn"] }
+                },
+                "to": [{ "consumer_key_code": "display_brightness_increment" }],
+                "type": "basic"
+              },
+              {
+                "conditions": [
+                  {
+                    "bundle_identifiers": [
+                      "com.microsoft.VSCode",
+                      "com.microsoft.VSCodeInsiders"
+                    ],
+                    "file_paths": ["/Cursor.app$", "/Cursor$"],
+                    "type": "frontmost_application_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "f3",
+                  "modifiers": { "mandatory": ["fn"] }
+                },
+                "to": [{ "apple_vendor_keyboard_key_code": "mission_control" }],
+                "type": "basic"
+              },
+              {
+                "conditions": [
+                  {
+                    "bundle_identifiers": [
+                      "com.microsoft.VSCode",
+                      "com.microsoft.VSCodeInsiders"
+                    ],
+                    "file_paths": ["/Cursor.app$", "/Cursor$"],
+                    "type": "frontmost_application_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "f4",
+                  "modifiers": { "mandatory": ["fn"] }
+                },
+                "to": [{ "apple_vendor_keyboard_key_code": "spotlight" }],
+                "type": "basic"
+              },
+              {
+                "conditions": [
+                  {
+                    "bundle_identifiers": [
+                      "com.microsoft.VSCode",
+                      "com.microsoft.VSCodeInsiders"
+                    ],
+                    "file_paths": ["/Cursor.app$", "/Cursor$"],
+                    "type": "frontmost_application_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "f5",
+                  "modifiers": { "mandatory": ["fn"] }
+                },
+                "to": [{ "consumer_key_code": "dictation" }],
+                "type": "basic"
+              },
+              {
+                "conditions": [
+                  {
+                    "bundle_identifiers": [
+                      "com.microsoft.VSCode",
+                      "com.microsoft.VSCodeInsiders"
+                    ],
+                    "file_paths": ["/Cursor.app$", "/Cursor$"],
+                    "type": "frontmost_application_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "f6",
+                  "modifiers": { "mandatory": ["fn"] }
+                },
+                "to": [{ "key_code": "f6" }],
+                "type": "basic"
+              },
+              {
+                "conditions": [
+                  {
+                    "bundle_identifiers": [
+                      "com.microsoft.VSCode",
+                      "com.microsoft.VSCodeInsiders"
+                    ],
+                    "file_paths": ["/Cursor.app$", "/Cursor$"],
+                    "type": "frontmost_application_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "f7",
+                  "modifiers": { "mandatory": ["fn"] }
+                },
+                "to": [{ "consumer_key_code": "rewind" }],
+                "type": "basic"
+              },
+              {
+                "conditions": [
+                  {
+                    "bundle_identifiers": [
+                      "com.microsoft.VSCode",
+                      "com.microsoft.VSCodeInsiders"
+                    ],
+                    "file_paths": ["/Cursor.app$", "/Cursor$"],
+                    "type": "frontmost_application_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "f8",
+                  "modifiers": { "mandatory": ["fn"] }
+                },
+                "to": [{ "consumer_key_code": "play_or_pause" }],
+                "type": "basic"
+              },
+              {
+                "conditions": [
+                  {
+                    "bundle_identifiers": [
+                      "com.microsoft.VSCode",
+                      "com.microsoft.VSCodeInsiders"
+                    ],
+                    "file_paths": ["/Cursor.app$", "/Cursor$"],
+                    "type": "frontmost_application_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "f9",
+                  "modifiers": { "mandatory": ["fn"] }
+                },
+                "to": [{ "consumer_key_code": "fast_forward" }],
+                "type": "basic"
+              },
+              {
+                "conditions": [
+                  {
+                    "bundle_identifiers": [
+                      "com.microsoft.VSCode",
+                      "com.microsoft.VSCodeInsiders"
+                    ],
+                    "file_paths": ["/Cursor.app$", "/Cursor$"],
+                    "type": "frontmost_application_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "f10",
+                  "modifiers": { "mandatory": ["fn"] }
+                },
+                "to": [{ "consumer_key_code": "mute" }],
+                "type": "basic"
+              },
+              {
+                "conditions": [
+                  {
+                    "bundle_identifiers": [
+                      "com.microsoft.VSCode",
+                      "com.microsoft.VSCodeInsiders"
+                    ],
+                    "file_paths": ["/Cursor.app$", "/Cursor$"],
+                    "type": "frontmost_application_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "f11",
+                  "modifiers": { "mandatory": ["fn"] }
+                },
+                "to": [{ "consumer_key_code": "volume_decrement" }],
+                "type": "basic"
+              },
+              {
+                "conditions": [
+                  {
+                    "bundle_identifiers": [
+                      "com.microsoft.VSCode",
+                      "com.microsoft.VSCodeInsiders"
+                    ],
+                    "file_paths": ["/Cursor.app$", "/Cursor$"],
+                    "type": "frontmost_application_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "f12",
+                  "modifiers": { "mandatory": ["fn"] }
+                },
+                "to": [{ "consumer_key_code": "volume_increment" }],
+                "type": "basic"
+              },
+              {
+                "conditions": [
+                  {
+                    "bundle_identifiers": [
+                      "com.microsoft.VSCode",
+                      "com.microsoft.VSCodeInsiders"
+                    ],
+                    "file_paths": ["/Cursor.app$", "/Cursor$"],
+                    "type": "frontmost_application_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "f1",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [{ "key_code": "f1" }],
+                "type": "basic"
+              },
+              {
+                "conditions": [
+                  {
+                    "bundle_identifiers": [
+                      "com.microsoft.VSCode",
+                      "com.microsoft.VSCodeInsiders"
+                    ],
+                    "file_paths": ["/Cursor.app$", "/Cursor$"],
+                    "type": "frontmost_application_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "f2",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [{ "key_code": "f2" }],
+                "type": "basic"
+              },
+              {
+                "conditions": [
+                  {
+                    "bundle_identifiers": [
+                      "com.microsoft.VSCode",
+                      "com.microsoft.VSCodeInsiders"
+                    ],
+                    "file_paths": ["/Cursor.app$", "/Cursor$"],
+                    "type": "frontmost_application_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "f3",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [{ "key_code": "f3" }],
+                "type": "basic"
+              },
+              {
+                "conditions": [
+                  {
+                    "bundle_identifiers": [
+                      "com.microsoft.VSCode",
+                      "com.microsoft.VSCodeInsiders"
+                    ],
+                    "file_paths": ["/Cursor.app$", "/Cursor$"],
+                    "type": "frontmost_application_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "f4",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [{ "key_code": "f4" }],
+                "type": "basic"
+              },
+              {
+                "conditions": [
+                  {
+                    "bundle_identifiers": [
+                      "com.microsoft.VSCode",
+                      "com.microsoft.VSCodeInsiders"
+                    ],
+                    "file_paths": ["/Cursor.app$", "/Cursor$"],
+                    "type": "frontmost_application_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "f5",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [{ "key_code": "f5" }],
+                "type": "basic"
+              },
+              {
+                "conditions": [
+                  {
+                    "bundle_identifiers": [
+                      "com.microsoft.VSCode",
+                      "com.microsoft.VSCodeInsiders"
+                    ],
+                    "file_paths": ["/Cursor.app$", "/Cursor$"],
+                    "type": "frontmost_application_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "f6",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [{ "key_code": "f6" }],
+                "type": "basic"
+              },
+              {
+                "conditions": [
+                  {
+                    "bundle_identifiers": [
+                      "com.microsoft.VSCode",
+                      "com.microsoft.VSCodeInsiders"
+                    ],
+                    "file_paths": ["/Cursor.app$", "/Cursor$"],
+                    "type": "frontmost_application_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "f7",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [{ "key_code": "f7" }],
+                "type": "basic"
+              },
+              {
+                "conditions": [
+                  {
+                    "bundle_identifiers": [
+                      "com.microsoft.VSCode",
+                      "com.microsoft.VSCodeInsiders"
+                    ],
+                    "file_paths": ["/Cursor.app$", "/Cursor$"],
+                    "type": "frontmost_application_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "f8",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [{ "key_code": "f8" }],
+                "type": "basic"
+              },
+              {
+                "conditions": [
+                  {
+                    "bundle_identifiers": [
+                      "com.microsoft.VSCode",
+                      "com.microsoft.VSCodeInsiders"
+                    ],
+                    "file_paths": ["/Cursor.app$", "/Cursor$"],
+                    "type": "frontmost_application_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "f9",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [{ "key_code": "f9" }],
+                "type": "basic"
+              },
+              {
+                "conditions": [
+                  {
+                    "bundle_identifiers": [
+                      "com.microsoft.VSCode",
+                      "com.microsoft.VSCodeInsiders"
+                    ],
+                    "file_paths": ["/Cursor.app$", "/Cursor$"],
+                    "type": "frontmost_application_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "f10",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [{ "key_code": "f10" }],
+                "type": "basic"
+              },
+              {
+                "conditions": [
+                  {
+                    "bundle_identifiers": [
+                      "com.microsoft.VSCode",
+                      "com.microsoft.VSCodeInsiders"
+                    ],
+                    "file_paths": ["/Cursor.app$", "/Cursor$"],
+                    "type": "frontmost_application_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "f11",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [{ "key_code": "f11" }],
+                "type": "basic"
+              },
+              {
+                "conditions": [
+                  {
+                    "bundle_identifiers": [
+                      "com.microsoft.VSCode",
+                      "com.microsoft.VSCodeInsiders"
+                    ],
+                    "file_paths": ["/Cursor.app$", "/Cursor$"],
+                    "type": "frontmost_application_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "f12",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [{ "key_code": "f12" }],
+                "type": "basic"
+              }
+            ]
+          }
+        ]
+      },
+      "name": "Default profile",
+      "selected": true,
+      "simple_modifications": [
+        {
+          "from": { "key_code": "caps_lock" },
+          "to": [{ "key_code": "escape" }]
+        }
+      ]
+    }
+  ]
+}
+


### PR DESCRIPTION
## Summary
This pull request introduces a new Karabiner configuration file and updates the Makefile scripts to handle the setup and cleanup of this configuration.

## Changes
- **makefiles/tools.mk**: Added a new target `karabiner` to create the necessary directory and symlink the Karabiner configuration file.
- **makefiles/utils.mk**: Updated the `clean` target to remove the Karabiner configuration file.
- **other/karabiner/karabiner.json**: Added a new Karabiner configuration file with custom key mappings for VSCode and Cursor applications.

## Additional Notes
- The Karabiner configuration file includes complex modifications for function keys (F1-F12) to act as standard function keys in VSCode and Cursor applications, with `fn` + function key performing the corresponding media function.
- The `clean` target in `makefiles/utils.mk` now ensures that the Karabiner configuration is also cleaned up.
- Ensure that Karabiner is installed and properly configured on your system to use these new key mappings.

