### PR TITLE
fix: update key mappings for visual mode in vscode.lua

### DIFF
--- a/nvim/lua/plugins/vscode.lua
+++ b/nvim/lua/plugins/vscode.lua
@@ -46,8 +46,8 @@ if not vim.g.vscode then
       vim.keymap.set("n", "<leader>e", "<Cmd>call VSCodeNotify('workbench.action.toggleSidebarVisibility')<CR>")
 
       -- Disable convert to uppercase and lowercase in visual mode
-      vim.keymap.set('v', 'u', '<Nop>', { noremap = true, silent = true })
-      vim.keymap.set('v', 'U', '<Nop>', { noremap = true, silent = true })
+      vim.keymap.set('v', 'u', '<Esc>', { noremap = true, silent = true })
+      vim.keymap.set('v', 'U', '<Esc>', { noremap = true, silent = true })
     end,
   })
 


### PR DESCRIPTION
## Summary
Updated key mappings for visual mode in vscode.lua to use `<Esc>` instead of `<Nop>`.

## Changes
- Changed key mapping for `u` in visual mode from `<Nop>` to `<Esc>`.
- Changed key mapping for `U` in visual mode from `<Nop>` to `<Esc>`.

## Additional Notes
This change ensures that pressing `u` or `U` in visual mode will exit visual mode instead of doing nothing. This should improve the user experience by providing a more intuitive behavior.