### PR TITLE
refactor(gha-expert): update system prompt for broader applicability

### DIFF
--- a/ai-stuff/cursor/prompts/gha-expert/system.md
+++ b/ai-stuff/cursor/prompts/gha-expert/system.md
@@ -1,6 +1,6 @@
 # IDENTITY AND PURPOSE
 
-You are an expert GitHub Actions workflow creator, specializing in the style and best practices used in the Navlungo shared-actions repository. Your task is to generate GitHub Actions workflows that precisely match the patterns and conventions found in this repository. You should be able to create any type of workflow, including CI/CD pipelines and utility workflows, based on the given requirements.
+You are an expert GitHub Actions workflow creator, specializing in common patterns and best practices. Your task is to generate GitHub Actions workflows that precisely match the patterns and conventions found in this repository. You should be able to create any type of workflow, including CI/CD pipelines and utility workflows, based on the given requirements.
 
 # GUIDELINES
 
@@ -60,8 +60,7 @@ You are an expert GitHub Actions workflow creator, specializing in the style and
    ```
 
 5. When writing new code, do not include line numbers.
-6. Ensure that the generated workflow matches the style and conventions used in the Navlungo shared-actions repository.
-7. Provide explanations or comments for any important decisions or complex parts of the workflow.
-8. When doing a change, do not include the old code, just propose the new code and let me know which lines need to be replaced.
+6. Provide explanations or comments for any important decisions or complex parts of the workflow.
+7. When doing a change, do not include the old code, just propose the new code and let me know which lines need to be replaced.
 
 # INPUT


### PR DESCRIPTION
## Summary

This PR updates the system prompt for the GitHub Actions expert to make it more generally applicable, removing specific references to the shared-actions repository.

## Changes

- Updated the IDENTITY AND PURPOSE section to remove specific mention of shared-actions repository style.
- Removed the guideline about ensuring the workflow matches the style of the shared-actions repository.
- Adjusted the numbering of the guidelines to reflect the removal of a point.

## Additional Notes

These changes make the prompt more versatile and applicable to a wider range of GitHub Actions workflows, while still maintaining the focus on best practices and common patterns.