### PR TITLE
docs: update commit message examples and flags

### DIFF
--- a/ai-stuff/cursor/prompts/create-commit/system.md
+++ b/ai-stuff/cursor/prompts/create-commit/system.md
@@ -28,7 +28,7 @@ You are an expert Git commit message generator, specializing in creating concise
 
 - Required: `<diff_context>`
 - Optional flags:
-  - `--with-body`: Include a detailed commit body using multiple `-m` flags.
+  - `--with-body`: Include a detailed commit body using a multiline string.
   - `--resolved-issues=<issue_numbers>`: Add resolved issues to the commit footer.
 
 # OUTPUT EXAMPLES
@@ -36,19 +36,39 @@ You are an expert Git commit message generator, specializing in creating concise
 1. Basic commit:
 
    ```bash
-   git commit -m 'fix: correct input validation in user registration'
+   git commit -m "fix: correct input validation in user registration"
    ```
 
 2. Commit with body:
 
    ```bash
-   git commit -m 'feat(auth): implement two-factor authentication' -m 'add sms and email options for 2fa' -m 'update user model to support 2fa preferences' -m 'create new api endpoints for 2fa setup and verification'
+   git commit -m "feat(auth): implement two-factor authentication'
+
+   - add sms and email options for 2fa
+   - update user model to support 2fa preferences
+   - create new api endpoints for 2fa setup and verification
    ```
 
 3. Commit with resolved issues:
 
    ```bash
-   git commit -m 'perf: optimize database queries for user search' -m 'implement caching for frequently accessed user data' -m 'refactor search algorithm to reduce complexity' -m 'resolves #123, resolves #456'
+   git commit -m "docs: update readme with additional troubleshooting steps for arm64 architecture
+
+   - clarified the instruction to replace debuggerPath in launch.json
+   - added steps to verify compatibility of cmake, clang, and clang++ with arm64 architecture
+   - provided example output for architecture verification commands
+   - included command to upgrade llvm using homebrew on macos
+   - added note to retry compilation process after ensuring compatibility"
+   ```
+
+4. Commit with filename in body:
+
+   ```bash
+   git commit -m "refactor: reorganize utility functions for better modularity
+
+   - moved helper functions from \`src/utils/helpers.js\` to \`src/utils/string-helpers.js\` and \`src/utils/array-helpers.js\`
+   - updated import statements in affected files
+   - added unit tests for newly separated utility functions"
    ```
 
 # INPUT


### PR DESCRIPTION
## Summary
This pull request updates the commit message examples and the description of the `--with-body` flag in the `ai-stuff/cursor/prompts/create-commit/system.md` file.

## Changes
- Updated the `--with-body` flag description to indicate the use of a multiline string instead of multiple `-m` flags.
- Revised the commit message examples to reflect the new multiline string format for commit bodies.
- Added a new example demonstrating how to include filenames in the commit body.

## Additional Notes
These changes aim to improve clarity and provide more accurate examples for generating commit messages. The updated examples should help users better understand how to format their commit messages, especially when including detailed commit bodies or filenames.