### PR TITLE
feat: add git alias to find parent branch

### DIFF
--- a/base.gitconfig
+++ b/base.gitconfig
@@ -138,7 +138,20 @@
     # a.k.a. ‘delete merged’
     dm = "!git branch --merged | grep -v '\\*' | xargs -n 1 git branch -d"
 
-
+    # Get the parent branch of the current branch
+    parent = "!f() { \
+    branch=$(git symbolic-ref --short HEAD); \
+    if [[ $branch =~ ^(main|master|develop)$ ]]; then \
+      echo \"You're already on a main branch: $branch\"; \
+    else \
+      parent_branch=$(git for-each-ref --format='%(refname:short)' refs/heads/ | grep -E '^(main|master|develop)' | head -n 1); \
+      if [ -z \"$parent_branch\" ]; then \
+        echo \"No common parent branch (main/master/develop) found.\"; \
+      else \
+        echo \"$parent_branch\"; \
+      fi; \
+    fi; \
+  }; f"
 
     # List contributors with number of commits
     contributors = shortlog --summary --numbered


### PR DESCRIPTION
## Summary
This pull request introduces a new git alias to the `base.gitconfig` file that allows users to find the parent branch of the current branch. This is particularly useful for workflows that involve multiple branches and need to identify the main branch (main/master/develop) from which the current branch was derived.

## Changes
- Added a new git alias `parent` to the `base.gitconfig` file.
- The alias runs a shell function that:
  - Checks if the current branch is one of the main branches (main/master/develop).
  - If not, it searches for the first main branch (main/master/develop) and prints it.
  - Provides appropriate messages if the current branch is already a main branch or if no main branch is found.