### PR TITLE
refactor(git): simplify parent branch detection alias

### DIFF
--- a/base.gitconfig
+++ b/base.gitconfig
@@ -142,19 +142,7 @@
     dc = "!git diff --staged | pbcopy"
 
     # Get the parent branch of the current branch
-    parent = "!f() { \
-        branch=$(git symbolic-ref --short HEAD); \
-        if [[ $branch =~ ^(main|master|develop)$ ]]; then \
-            echo \"You're already on a main branch: $branch\"; \
-        else \
-            parent_branch=$(git for-each-ref --format='%(refname:short)' refs/heads/ | grep -E '^(main|master|develop)' | head -n 1); \
-            if [ -z \"$parent_branch\" ]; then \
-                echo \"No common parent branch (main/master/develop) found.\"; \
-            else \
-                echo \"$parent_branch\"; \
-            fi; \
-        fi; \
-    }; f"
+    parent = "!git for-each-ref --format='%(refname:short)' refs/heads/ | grep -E '^(main|master|develop)' | head -n 1"
 
     # List contributors with number of commits
     contributors = shortlog --summary --numbered


### PR DESCRIPTION
## Summary

Simplifies the git parent alias by removing conditional logic and keeping only the essential command to detect the main parent branch (main/master/develop).

## Changes

- Simplified `parent` git alias to directly return the first matching parent branch (main/master/develop)
- Removed conditional checks for current branch type
- Removed error message handling for cases when no parent branch is found

## Additional Notes

- The simplified version always returns the first matching parent branch (main/master/develop)
- This change assumes that at least one of these branches exists in the repository
- The new implementation is more concise and performs fewer operations