### PR TITLE
feat(git): add lc alias for formatted commit log display

### DIFF
--- a/base.gitconfig
+++ b/base.gitconfig
@@ -151,6 +151,9 @@
     # Show the user email for the current repository.
     whoami = config user.email
 
+    # Print latest commits with committer
+    lc = "!git log --pretty=format:'%C(yellow)%h  %Cblue%ad  %Creset%s%Cgreen  [%cn] %Cred%d' --decorate --date=short -n 10"
+
     # Create a release branch from the current branch named release/DDMMYYY. If a release branch already exists, a new one will not be created with -1 appended to the name. if it exists as well -2 will be appended and so on.
     release = "!f() { \
         local branch=$(git rev-parse --abbrev-ref HEAD); \


### PR DESCRIPTION
## Summary

Adds a new git alias `lc` (log commits) that provides a formatted display of recent commit history with committer information.

## Changes

- Added new git alias `lc` in base.gitconfig
- The alias shows the last 10 commits with:
  - Commit hash (yellow)
  - Date (blue)
  - Commit message
  - Committer name (green)
  - Branch/tag decorations (red)
- Uses color formatting for better readability
- Includes short date format for concise display

## Additional Notes

This alias provides a quick way to view recent commit history with relevant metadata in a visually organized format. The color coding helps distinguish different elements of the commit information, making it easier to scan through the log output.