### PR TITLE
feat(git): add ls alias for listing all branches

### DIFF
--- a/base.gitconfig
+++ b/base.gitconfig
@@ -148,6 +148,9 @@
     # List contributors with number of commits
     contributors = shortlog --summary --numbered
 
+    # List all branches
+    ls = "!git branch -a"
+
     # Show the user email for the current repository.
     whoami = config user.email
 


### PR DESCRIPTION
## Summary

Add a new git alias `ls` that shows all branches (both local and remote) using `git branch -a`. This provides a quick and intuitive way to view all available branches.

## Changes

- Added new git alias `ls` that maps to `git branch -a`
- The alias provides a shorter, more memorable command for listing branches
- Shows both local and remote branches in one view

## Additional Notes

- The alias follows the common Unix/Linux convention where `ls` is used to list items
- This complements existing branch-related aliases in the configuration
- The command is simple and straightforward, making it easy to remember and use